### PR TITLE
Fix excessive static data causing library bloat.

### DIFF
--- a/src/common/feedback.h
+++ b/src/common/feedback.h
@@ -119,7 +119,7 @@ struct rohc_feedback_opt_charac
 		ROHC_FEEDBACK_OPT_CRC_SUGGESTED,
 		ROHC_FEEDBACK_OPT_CRC_NOT_REQUIRED,
 	} crc_req;
-	size_t max_occurs[0xffff + 1];
+	size_t max_occurs[ROHC_PROFILE_MAX];
 };
 
 
@@ -157,7 +157,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 0, /* RFC6846 §8.3.2 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_REJECT] = {
@@ -176,7 +175,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 1, /* RFC6846 §8.3.2.1 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_SN_NOT_VALID] = {
@@ -195,7 +193,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 1, /* RFC6846 §8.3.2.2 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_SN] = {
@@ -214,7 +211,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 1, /* RFC6846 §8.3.2.3 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = 1, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = 1, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_CLOCK] = {
@@ -233,7 +229,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 0, /* RFC6846 §8.3.2 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = 0, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_JITTER] = {
@@ -252,7 +247,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 0, /* RFC6846 §8.3.2 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = 0, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_LOSS] = {
@@ -271,7 +265,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 0, /* RFC6846 §8.3.2 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_CV_REQUEST] = {
@@ -290,7 +283,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 0, /* RFC6846 §8.3.2 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = 0, /* same as RTP */
 			[ROHC_PROFILE_UDPLITE]      = 0, /* same as UDP */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0,
 		}
 	},
 	[ROHC_FEEDBACK_OPT_CONTEXT_MEMORY] = {
@@ -309,7 +301,6 @@ static const struct rohc_feedback_opt_charac
 			[ROHC_PROFILE_TCP]          = 1, /* RFC6846 §8.3.2.4 */
 			[ROHC_PROFILE_UDPLITE_RTP]  = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* RFC4019 §5.7 */
 			[ROHC_PROFILE_UDPLITE]      = ROHC_FEEDBACK_OPT_MAX_OCCURS, /* RFC4019 §5.7 */
-			[ROHC_PROFILE_UDPLITE+1 ... 0xffff] = 0
 		}
 	},
 	[ROHC_FEEDBACK_OPT_UNKNOWN_10] = {

--- a/src/common/rohc.h
+++ b/src/common/rohc.h
@@ -231,6 +231,8 @@ typedef enum
 	/** The ROHC UDP-Lite profile (RFC 4019, section 7) */
 	ROHC_PROFILE_UDPLITE      = 0x0008,
 
+	ROHC_PROFILE_MAX          = 0x0009,
+
 } rohc_profile_t;
 
 

--- a/src/comp/rohc_comp.c
+++ b/src/comp/rohc_comp.c
@@ -2981,6 +2981,7 @@ static bool rohc_comp_feedback_check_opts(const struct rohc_comp_ctxt *const con
                                           const size_t opts_present[ROHC_FEEDBACK_OPT_MAX])
 {
 	uint8_t opt_type;
+	assert(context->profile->id < ROHC_PROFILE_MAX);
 
 	for(opt_type = 0; opt_type < ROHC_FEEDBACK_OPT_MAX; opt_type++)
 	{


### PR DESCRIPTION
Roughly 8MiB of zeroed data is allocated on 64 bit targets increasing
the shared lib size by an order of magnitude.

This change reduces the number of array entries for profiles to the
strict number required for the implementation instead of the largest
possible number defined by the ROHC standards.