### PR TITLE
Add wrappers for Linux kernel header files

### DIFF
--- a/linux/include/stdbool.h
+++ b/linux/include/stdbool.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Didier Barvaux
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file   linux/include/stdbool.h
+ * @brief  Define boolean data type for the Linux kernel
+ * @author Didier Barvaux <didier@barvaux.org>
+ */
+
+#ifndef ROHC_KERNEL_STDBOOL_H
+#define ROHC_KERNEL_STDBOOL_H
+
+#ifndef __KERNEL__
+#	error "for Linux kernel only!"
+#endif
+
+#include <linux/types.h>
+
+#endif /* ROHC_KERNEL_STDBOOL_H */

--- a/linux/include/string.h
+++ b/linux/include/string.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Didier Barvaux
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file   linux/include/string.h
+ * @brief  Define string handling functions for the Linux kernel
+ * @author Didier Barvaux <didier@barvaux.org>
+ */
+
+#ifndef ROHC_KERNEL_STRING_H
+#define ROHC_KERNEL_STRING_H
+
+#ifndef __KERNEL__
+#	error "for Linux kernel only!"
+#endif
+
+#include <linux/string.h>
+
+#endif /* ROHC_KERNEL_STRING_H */

--- a/src/common/ip.c
+++ b/src/common/ip.c
@@ -32,9 +32,7 @@
 #include "protocols/ipv4.h"
 #include "protocols/ipv6.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/common/rohc_add_cid.c
+++ b/src/common/rohc_add_cid.c
@@ -27,11 +27,7 @@
 #include "rohc_bit_ops.h"
 
 #include <stdint.h>
-#ifdef __KERNEL__
-#  include <linux/types.h>
-#else
-#  include <stdbool.h>
-#endif
+#include <stdbool.h>
 
 
 /**

--- a/src/common/rohc_list.c
+++ b/src/common/rohc_list.c
@@ -26,9 +26,7 @@
 #include "rohc_list.h"
 
 #include <stdlib.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/common/rohc_packets.c
+++ b/src/common/rohc_packets.c
@@ -25,9 +25,7 @@
 #include "rohc_packets.h"
 
 #include <assert.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 /**

--- a/src/comp/c_esp.c
+++ b/src/comp/c_esp.c
@@ -32,14 +32,8 @@
 #include "protocols/esp.h"
 #include "rohc_utils.h"
 
-#ifdef __KERNEL__
-#  include <linux/types.h>
-#else
-#  include <stdbool.h>
-#endif
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <stdbool.h>
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/comp/c_ip.c
+++ b/src/comp/c_ip.c
@@ -29,9 +29,7 @@
 #include "rohc_traces_internal.h"
 #include "rohc_utils.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/comp/c_rtp.c
+++ b/src/comp/c_rtp.c
@@ -36,9 +36,7 @@
 #include "crc.h"
 
 #include <stdlib.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/comp/c_tcp.c
+++ b/src/comp/c_tcp.c
@@ -46,10 +46,9 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 #ifdef __KERNEL__
 #  include <endian.h>
-#else
-#  include <string.h>
 #endif
 
 #include "config.h" /* for WORDS_BIGENDIAN */

--- a/src/comp/c_tcp_opts_list.c
+++ b/src/comp/c_tcp_opts_list.c
@@ -31,9 +31,7 @@
 #include "schemes/tcp_ts.h"
 #include "schemes/tcp_sack.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 /** The length of the table mapping for TCP options */

--- a/src/comp/c_udp.c
+++ b/src/comp/c_udp.c
@@ -35,9 +35,7 @@
 #include "protocols/udp.h"
 
 #include <stdlib.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/comp/c_udp_lite.c
+++ b/src/comp/c_udp_lite.c
@@ -35,9 +35,7 @@
 #include "protocols/udp_lite.h"
 
 #include <stdlib.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/comp/rohc_comp.c
+++ b/src/comp/rohc_comp.c
@@ -58,15 +58,9 @@
 
 #include "config.h" /* for PACKAGE_(NAME|URL|VERSION) */
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <stdlib.h>
-#ifdef __KERNEL__
-#  include <linux/types.h>
-#else
-#  include <stdbool.h>
-#endif
+#include <stdbool.h>
 #include <assert.h>
 #include <stdarg.h>
 

--- a/src/comp/rohc_comp_rfc3095.c
+++ b/src/comp/rohc_comp_rfc3095.c
@@ -43,9 +43,7 @@
 #include "crc.h"
 
 #include <stdint.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 #include "config.h"

--- a/src/comp/schemes/comp_list.c
+++ b/src/comp/schemes/comp_list.c
@@ -26,9 +26,7 @@
 #include "schemes/comp_list.h"
 #include "rohc_comp_internals.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 /** Print a warning trace for the given list compression context */

--- a/src/comp/schemes/comp_list_ipv6.c
+++ b/src/comp/schemes/comp_list_ipv6.c
@@ -25,9 +25,7 @@
 
 #include "schemes/comp_list_ipv6.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 static int get_index_ipv6_table(const uint8_t next_header_type,

--- a/src/comp/schemes/comp_wlsb.c
+++ b/src/comp/schemes/comp_wlsb.c
@@ -28,9 +28,7 @@
 #include "comp_wlsb.h"
 #include "interval.h" /* for the rohc_f_*bits() functions */
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/comp/schemes/rfc4996.c
+++ b/src/comp/schemes/rfc4996.c
@@ -27,9 +27,8 @@
 #include "rohc_utils.h"
 #include "protocols/tcp.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#else
+#include <string.h>
+#ifdef __KERNEL__
 #  include <bitops.h> /* for __builtin_popcount() in Linux kernel */
 #endif
 #include <assert.h>

--- a/src/comp/schemes/tcp_ts.c
+++ b/src/comp/schemes/tcp_ts.c
@@ -24,9 +24,7 @@
 
 #include "tcp_ts.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 /**

--- a/src/decomp/d_esp.c
+++ b/src/decomp/d_esp.c
@@ -35,9 +35,7 @@
 #include "schemes/decomp_wlsb.h"
 
 #include <stdint.h>
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/d_rtp.c
+++ b/src/decomp/d_rtp.c
@@ -40,9 +40,7 @@
 #include "protocols/udp.h"
 #include "protocols/rtp.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/d_tcp.c
+++ b/src/decomp/d_tcp.c
@@ -49,9 +49,7 @@
 
 #include "config.h" /* for WORDS_BIGENDIAN and ROHC_RFC_STRICT_DECOMPRESSOR */
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <stdint.h>
 
 

--- a/src/decomp/d_tcp_dynamic.c
+++ b/src/decomp/d_tcp_dynamic.c
@@ -34,9 +34,7 @@
 #include "protocols/ip_numbers.h"
 #include "schemes/rfc4996.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 static int tcp_parse_dynamic_ip(const struct rohc_decomp_ctxt *const context,
                                 const uint8_t *const rohc_packet,

--- a/src/decomp/d_tcp_irregular.c
+++ b/src/decomp/d_tcp_irregular.c
@@ -32,9 +32,7 @@
 #include "d_tcp_opts_list.h"
 #include "rohc_utils.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 static int tcp_parse_irregular_ip(const struct rohc_decomp_ctxt *const context,
                                   const ip_context_t *const ip_context,

--- a/src/decomp/d_tcp_opts_list.c
+++ b/src/decomp/d_tcp_opts_list.c
@@ -36,9 +36,7 @@
 
 #include "config.h" /* for ROHC_RFC_STRICT_DECOMPRESSOR */
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 struct d_tcp_opt_index /* TODO */

--- a/src/decomp/d_tcp_static.c
+++ b/src/decomp/d_tcp_static.c
@@ -33,9 +33,7 @@
 #include "rohc_utils.h"
 #include "protocols/ip_numbers.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 static int tcp_parse_static_ip(const struct rohc_decomp_ctxt *const context,

--- a/src/decomp/d_udp.c
+++ b/src/decomp/d_udp.c
@@ -34,9 +34,7 @@
 #include "crc.h"
 #include "protocols/udp.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/d_udp_lite.c
+++ b/src/decomp/d_udp_lite.c
@@ -36,9 +36,7 @@
 #include "crc.h"
 #include "protocols/udp_lite.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 /*

--- a/src/decomp/d_uncompressed.c
+++ b/src/decomp/d_uncompressed.c
@@ -31,9 +31,7 @@
 #include "crc.h"
 #include "rohc_decomp_detect_packet.h" /* for rohc_decomp_packet_is_ir() */
 
-#ifndef __KERNEL__
-#	include <string.h>
-#endif
+#include <string.h>
 
 
 /*

--- a/src/decomp/feedback_create.c
+++ b/src/decomp/feedback_create.c
@@ -33,9 +33,7 @@
 #ifdef ROHC_FEEDBACK_DEBUG
 #  include <stdio.h>
 #endif
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/rohc_decomp.c
+++ b/src/decomp/rohc_decomp.c
@@ -51,9 +51,7 @@
 #include "rohc_decomp_detect_packet.h"
 #include "crc.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <stdarg.h>
 #include <assert.h>
 

--- a/src/decomp/rohc_decomp_rfc3095.c
+++ b/src/decomp/rohc_decomp_rfc3095.c
@@ -43,9 +43,7 @@
 
 #include "config.h" /* for WORDS_BIGENDIAN definition */
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/schemes/decomp_list.c
+++ b/src/decomp/schemes/decomp_list.c
@@ -27,9 +27,7 @@
 
 #include "rohc_bit_ops.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/schemes/decomp_list_ipv6.c
+++ b/src/decomp/schemes/decomp_list_ipv6.c
@@ -27,9 +27,7 @@
 
 #include "rohc_traces_internal.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 static bool check_ip6_item(const struct list_decomp *const decomp,

--- a/src/decomp/schemes/decomp_wlsb.c
+++ b/src/decomp/schemes/decomp_wlsb.c
@@ -27,9 +27,7 @@
 #include "decomp_wlsb.h"
 #include "interval.h" /* for the rohc_f_32bits() function */
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/schemes/rfc4996.c
+++ b/src/decomp/schemes/rfc4996.c
@@ -36,9 +36,7 @@
 #include "rohc_packets.h"
 #include "rohc_decomp.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 #include <assert.h>
 
 

--- a/src/decomp/schemes/tcp_ts.c
+++ b/src/decomp/schemes/tcp_ts.c
@@ -30,9 +30,7 @@
 
 #include "rohc_utils.h"
 
-#ifndef __KERNEL__
-#  include <string.h>
-#endif
+#include <string.h>
 
 
 /**


### PR DESCRIPTION
This patch cleans up the code and fixes Linux kernel module build. Build error was mentioned in https://answers.launchpad.net/rohc/+question/399335 . 
