### PR TITLE
Fix compilation error when using gcc-7

### DIFF
--- a/src/decomp/rohc_decomp.c
+++ b/src/decomp/rohc_decomp.c
@@ -2477,12 +2477,10 @@ bool rohc_decomp_get_last_packet_info(const struct rohc_decomp *const decomp,
 		info->is_duplicated = decomp->last_context->is_duplicated;
 
 		/* new fields added by minor versions */
-		switch(info->version_minor)
+		if((info->version_minor == 2) || (info->version_minor == 1))
 		{
-			case 0:
-				/* nothing to add */
-				break;
-			case 2:
+			if(info->version_minor == 2)
+			{
 				/* new fields in 0.2 */
 				info->total_last_comp_size =
 					decomp->last_context->total_last_compressed_size;
@@ -2492,22 +2490,23 @@ bool rohc_decomp_get_last_packet_info(const struct rohc_decomp *const decomp,
 					decomp->last_context->total_last_uncompressed_size;
 				info->header_last_uncomp_size =
 					decomp->last_context->header_last_uncompressed_size;
-				/* no break to also add new fields in 0.1 */
-			case 1:
-				/* new fields in 0.1 */
-				info->corrected_crc_failures =
-					decomp->last_context->corrected_crc_failures;
-				info->corrected_sn_wraparounds =
-					decomp->last_context->corrected_sn_wraparounds;
-				info->corrected_wrong_sn_updates =
-					decomp->last_context->corrected_wrong_sn_updates;
-				info->packet_type = decomp->last_context->packet_type;
-				break;
-			default:
-				rohc_error(decomp, ROHC_TRACE_DECOMP, ROHC_PROFILE_GENERAL,
-				           "unsupported minor version (%u) of the structure for "
-				           "last packet information", info->version_minor);
-				goto error;
+			}
+
+			/* new fields in 0.1 */
+			info->corrected_crc_failures =
+				decomp->last_context->corrected_crc_failures;
+			info->corrected_sn_wraparounds =
+				decomp->last_context->corrected_sn_wraparounds;
+			info->corrected_wrong_sn_updates =
+				decomp->last_context->corrected_wrong_sn_updates;
+			info->packet_type = decomp->last_context->packet_type;
+		}
+		else if(info->version_minor != 0)
+		{
+			rohc_error(decomp, ROHC_TRACE_DECOMP, ROHC_PROFILE_GENERAL,
+			           "unsupported minor version (%u) of the structure for "
+			           "last packet information", info->version_minor);
+			goto error;
 		}
 	}
 	else


### PR DESCRIPTION
Here is the compile error:

```
  CC librohc_decomp_la-rohc_decomp.lo
rohc_decomp.c: In function ‘rohc_decomp_get_last_packet_info’:
rohc_decomp.c:2493:35: error: this statement may fall through [-Werror=implicit-fallthrough=]
     info->header_last_uncomp_size =
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
      decomp->last_context->header_last_uncompressed_size;
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rohc_decomp.c:2496:4: note: here
    case 1:
    ^~~~
cc1: all warnings being treated as errors
Makefile:576: recipe for target 'librohc_decomp_la-rohc_decomp.lo' failed
make[4]: *** [librohc_decomp_la-rohc_decomp.lo] Error 1
```

Refactor code to avoid compilation error.