### PR TITLE
use rohc_do_div macro for uint64_t/uint32_t division

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -41,6 +41,7 @@ private_headers = \
 	rohc_internal.h \
 	rohc_bit_ops.h \
 	rohc_debug.h \
+	rohc_math64.h \
 	rohc_traces_internal.h \
 	rohc_time_internal.h \
 	rohc_utils.h \

--- a/src/common/rohc_math64.h
+++ b/src/common/rohc_math64.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Didier Barvaux
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @file    rohc_math64.h
+ * @brief   ROHC internal functions for 64-bit math
+ * @author  Didier Barvaux <didier@barvaux.org>
+ */
+
+#ifndef ROHC_MATH64_H
+#define ROHC_MATH64_H
+
+/*
+ * rohc_do_div macro modifies 64-bit dividend in-place
+ * and returns the 32-bit remainder
+ */
+
+#ifdef __KERNEL__
+# include <asm/div64.h>
+# define rohc_do_div(dividend, divisor) do_div(dividend, divisor)
+#else
+# define rohc_do_div(dividend, divisor) ({			\
+	uint32_t __divisor = (divisor);				\
+	uint32_t __remainder;					\
+	__remainder = ((uint64_t)(dividend)) % __divisor;	\
+	(dividend) = ((uint64_t)(dividend)) / __divisor;	\
+	__remainder;						\
+ })
+#endif
+
+#endif /* ROHC_MATH64_H */
+

--- a/src/common/rohc_time_internal.h
+++ b/src/common/rohc_time_internal.h
@@ -29,6 +29,7 @@
 #ifndef ROHC_TIME_INTERNAL_H
 #define ROHC_TIME_INTERNAL_H
 
+#include "rohc_math64.h"
 #include "rohc_time.h" /* for public definition of struct rohc_ts */
 
 #ifndef __KERNEL__
@@ -57,7 +58,7 @@ static inline uint64_t rohc_time_interval(const struct rohc_ts begin,
 	interval *= 1000000000UL;       /* convert in nanoseconds */
 	interval += end.nsec;           /* additional end nanoseconds */
 	interval -= begin.nsec;         /* superfluous begin nanoseconds */
-	interval /= 1000UL;             /* convert in microseconds */
+	rohc_do_div(interval, 1000UL);  /* convert in microseconds */
 
 	return interval;
 }


### PR DESCRIPTION
This fix re-enables 32-bit CPU support for ROHC Linux kernel module.

The issue was mentioned in https://lists.launchpad.net/rohc/msg02178.html . ROHC library uses 64-bit division in couple of places. But this operation is not available out-of-the box for Linux kernel module on 32-bit CPUs. We need to use do_div macro instead.

It's not that I actually _request_ to pull this patch in. You might use it as a reference or not use it at all. It obviously adds some clutter into ROHC library code. I have no commercial interest on my side. My former employer never used the library in production. Kernel-level tests still fail and JTMTC I have no idea if the kernel module functions as expected.

Btw, rohc_do_div implementation for userspace came from Linux kernel source code. I'm not quite sure if it's ok to bring those lines to GPL/LGPL-licensed code from GPL-licensed. Maybe it's worth rewriting from scratch :)

