### PR TITLE
add function to create context with specific cid

### DIFF
--- a/src/comp/rohc_comp.h
+++ b/src/comp/rohc_comp.h
@@ -313,6 +313,11 @@ rohc_status_t ROHC_EXPORT rohc_compress4(struct rohc_comp *const comp,
                                          struct rohc_buf *const rohc_packet)
 	__attribute__((warn_unused_result));
 
+rohc_status_t ROHC_EXPORT rohc_comp_create_context(struct rohc_comp *const comp,
+                             const struct rohc_buf uncomp_packet,
+                             const rohc_cid_t cid_to_use)
+	__attribute__((warn_unused_result));
+
 rohc_status_t ROHC_EXPORT rohc_comp_pad(struct rohc_comp *const comp,
                                         struct rohc_buf *const rohc_packet,
                                         const size_t min_pkt_len)

--- a/src/comp/rohc_comp_rfc3095.c
+++ b/src/comp/rohc_comp_rfc3095.c
@@ -436,9 +436,6 @@ static void ip_header_info_new(struct ip_header_info *const header_info,
 	header_info->version = ip_get_version(ip);
 	header_info->static_chain_end = false;
 
-	/* we haven't seen any header so far */
-	header_info->is_first_header = true;
-
 	/* version specific initialization */
 	if(header_info->version == IPV4)
 	{
@@ -462,6 +459,12 @@ static void ip_header_info_new(struct ip_header_info *const header_info,
 		rohc_comp_list_ipv6_new(&header_info->info.v6.ext_comp, list_trans_nr,
 		                        trace_cb, trace_cb_priv, profile_id);
 	}
+
+	/* init the IP information with the IP header */
+	update_context_ip_hdr(header_info, ip);
+
+	/* we haven't seen any header so far */
+	header_info->is_first_header = true;
 }
 
 

--- a/src/librohc.symbols
+++ b/src/librohc.symbols
@@ -42,6 +42,7 @@ rohc_comp_enable_profiles
 rohc_comp_disable_profile
 rohc_comp_disable_profiles
 rohc_compress4
+rohc_comp_create_context
 rohc_comp_pad
 rohc_comp_deliver_feedback2
 rohc_comp_get_segment2


### PR DESCRIPTION
Hello Didier. In the program I'm working on I must be able to choose the context id used for a stream. I added a function rohc_comp_create_context to that end. Do you think you could merge such a feature in your repo ?