### PR TITLE
fix: rohc_buf_* export preventing compilation in kernel module mode

### DIFF
--- a/linux/kmod.c
+++ b/linux/kmod.c
@@ -59,18 +59,6 @@ EXPORT_SYMBOL_GPL(rohc_packet_is_ir);
 EXPORT_SYMBOL_GPL(rohc_packet_carry_static_info);
 EXPORT_SYMBOL_GPL(rohc_packet_carry_crc_7_or_8);
 
-EXPORT_SYMBOL_GPL(rohc_buf_is_malformed);
-EXPORT_SYMBOL_GPL(rohc_buf_is_empty);
-EXPORT_SYMBOL_GPL(rohc_buf_push);
-EXPORT_SYMBOL_GPL(rohc_buf_pull);
-EXPORT_SYMBOL_GPL(rohc_buf_avail_len);
-EXPORT_SYMBOL_GPL(rohc_buf_data_at);
-EXPORT_SYMBOL_GPL(rohc_buf_data);
-EXPORT_SYMBOL_GPL(rohc_buf_prepend);
-EXPORT_SYMBOL_GPL(rohc_buf_append);
-EXPORT_SYMBOL_GPL(rohc_buf_append_buf);
-EXPORT_SYMBOL_GPL(rohc_buf_reset);
-
 
 /*
  * Compression API


### PR DESCRIPTION
Scope: kernel module compilation

The following error is present across various linux systems and architectures with kernel version 5.10+ (tested with gcc-11.3+):
https://answers.launchpad.net/rohc/+question/707783
ERROR: modpost: "rohc_buf_is_empty" [...] is a static EXPORT_SYMBOL_GPL
ERROR: modpost: "rohc_buf_is_malformed" [...] is a static EXPORT_SYMBOL_GPL ...

I target branch 2.3.x because I only worked on v2.3.1